### PR TITLE
Removed RS + skip

### DIFF
--- a/jobs/Full
+++ b/jobs/Full
@@ -14,7 +14,6 @@ PBR
 Physical_Lights
 Render_Layer
 Render_Mode
-Render_Stamp
 RPR_Nodes
 Smoke
 Uber

--- a/jobs/Tests/Pass_Limit/case_list.json
+++ b/jobs/Tests/Pass_Limit/case_list.json
@@ -90,7 +90,7 @@
 			"samplesMax": 100, 
 			"adaptiveNoiseThreshold": 0, 
 			"timeLimit": 0,
-			"status": "active"
+			"status": "skipped"
 		},
 		{
 			"name": "MAX_RS_PS_008",
@@ -103,7 +103,7 @@
 			"samplesMax": 500, 
 			"adaptiveNoiseThreshold": 0, 
 			"timeLimit": 0,
-			"status": "active"
+			"status": "skipped"
 		},
 		{
 			"name": "MAX_RS_PS_009",
@@ -116,7 +116,7 @@
 			"samplesMax": 1000, 
 			"adaptiveNoiseThreshold": 0, 
 			"timeLimit": 0,
-			"status": "active"
+			"status": "skipped"
 		},
 		{
 			"name": "MAX_RS_PS_010",
@@ -256,7 +256,7 @@
 			"samplesMax": null, 
 			"adaptiveNoiseThreshold": 0, 
 			"timeLimit": 61,
-			"status": "active"
+			"status": "skipped"
 		},
 		{
 			"name": "MAX_RS_PS_021",
@@ -269,7 +269,7 @@
 			"samplesMax": null, 
 			"adaptiveNoiseThreshold": 0, 
 			"timeLimit": 119,
-			"status": "active"
+			"status": "skipped"
 		}
 	]
 }

--- a/jobs/Tests/Render_Stamp/case_list.json
+++ b/jobs/Tests/Render_Stamp/case_list.json
@@ -4,7 +4,6 @@
 		{
 			"name": "MAX_RS_RS_001",
 			"script_info": [
-				"Do not compare",
 				"Default stamp"
 			],
 			"status": "active",
@@ -13,7 +12,6 @@
 		{
 			"name": "MAX_RS_RS_002",
 			"script_info": [
-				"Do not compare",
 				"Radeon ProRender for 3ds Max %b | CPU %c | GPU %g | Render mode %r | Render device %h'"
 			],
 			"status": "active",
@@ -22,7 +20,6 @@
 		{
 			"name": "MAX_RS_RS_003",
 			"script_info": [
-				"Do not compare",
 				"Radeon ProRender for 3ds Max %b | Computer name %i | Current date %d"
 			],
 			"status": "active",

--- a/jobs/Tests/Render_Stamp/case_list.json
+++ b/jobs/Tests/Render_Stamp/case_list.json
@@ -4,25 +4,28 @@
 		{
 			"name": "MAX_RS_RS_001",
 			"script_info": [
+				"Do not compare",
 				"Default stamp"
 			],
-			"status": "skipped",
+			"status": "active",
 			"scene_name": "base_scene.max"
 		},
 		{
 			"name": "MAX_RS_RS_002",
 			"script_info": [
+				"Do not compare",
 				"Radeon ProRender for 3ds Max %b | CPU %c | GPU %g | Render mode %r | Render device %h'"
 			],
-			"status": "skipped",
+			"status": "active",
 			"scene_name": "base_scene.max"
 		},
 		{
 			"name": "MAX_RS_RS_003",
 			"script_info": [
+				"Do not compare",
 				"Radeon ProRender for 3ds Max %b | Computer name %i | Current date %d"
 			],
-			"status": "skipped",
+			"status": "active",
 			"scene_name": "base_scene.max"
 		}
 	]


### PR DESCRIPTION
Removed render stamp cases from weekly (group was completely skipped and workaround wasn't implemented) to not ruin builds statuses (e.g. https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMaxPlugin-WeeklyFull/49/ is red, while it should be yellow) and skipped issue with depth ray (https://amdrender.atlassian.net/browse/RPRMAX-726)