### PR TITLE
Add saving of missing param 'testcase_timeout_exceeded'

### DIFF
--- a/jobs/Scripts/Templates/base_function.ms
+++ b/jobs/Scripts/Templates/base_function.ms
@@ -87,6 +87,7 @@ function buildReport test_case script_info render_time filename test_status pass
         resolution_y: renderHeight \
         script_info: script_info \
         group_timeout_exceeded: false \
+        testcase_timeout_exceeded: false \
         testcase_timeout: 0 \
         message: (bi.list()) \
 


### PR DESCRIPTION
### Jira Ticket
* None
### Purpose
* Add saving of missing param 'testcase_timeout_exceeded' (without it CompareByJson script crashes)
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProRenderMaxPluginManual/1010/