### PR TITLE
skipped failed

### DIFF
--- a/jobs/Tests/Smoke/case_list.json
+++ b/jobs/Tests/Smoke/case_list.json
@@ -44,7 +44,7 @@
                 "EXR"
             ],
             "pass_limit": 400,
-            "status": "active"
+            "status": "skipped"
         },
         {
             "name": "MAX_SM_008",
@@ -53,7 +53,7 @@
                 "Test Sun"
             ],
             "pass_limit": 400,
-            "status": "active"
+            "status": "skipped"
         },
         {
             "name": "MAX_SM_009",


### PR DESCRIPTION
Purpose:
To skip failed on weekly

Report:
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMaxPlugin-WeeklyFull/77/Test_20Report/